### PR TITLE
Add blog post front matter template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 _site
-_drafts
 .bundle
 .sass-cache
 .jekyll-cache

--- a/_drafts/template.md
+++ b/_drafts/template.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "Post Title"
+date: 2026-01-01 12:00:00 +0100
+description: "Short description for SEO and link previews (1-2 sentences)."
+tags: []
+---
+
+Write your post here.


### PR DESCRIPTION
Adds `_drafts/template.md` as a starting point for new blog posts, and removes `_drafts` from `.gitignore` so drafts can be version-controlled.

**Usage:** Copy `_drafts/template.md` → `_posts/YYYY-MM-DD-title.md`, fill in the front matter, write the post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)