### PR TITLE
Redesign blog post layout with hashtag tags

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,13 +1,35 @@
 {% include header.html %}
 <main>
-  <div class="container">
-    <header class="post-header">
-      <h1>{{ page.title }}</h1>
-      <p class="post-date">{{ page.date | date: "%B %d, %Y" }}</p>
-    </header>
-    <article class="post-body">
-      {{ content }}
-    </article>
+  <div class="post-page">
+    <div class="container">
+
+      <a href="/posts/" class="post-back">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        All posts
+      </a>
+
+      <header class="post-header">
+        {% if page.tags.size > 0 %}
+        <div class="post-tags">{% for tag in page.tags %}<span class="post-tag">#{{ tag }}</span>{% endfor %}</div>
+        {% endif %}
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta-row">
+          <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+          <span class="meta-sep" aria-hidden="true">·</span>
+          {% assign words = content | number_of_words %}
+          <span>{{ words | divided_by: 200 | plus: 1 }} min read</span>
+        </div>
+      </header>
+
+      <article class="post-body">
+        {{ content }}
+      </article>
+
+      <footer class="post-footer">
+        <a href="/posts/" class="btn btn-secondary">← Back to all posts</a>
+      </footer>
+
+    </div>
   </div>
 </main>
 {% include footer.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,37 @@
         {{ content }}
       </article>
 
+      {% comment %}Related posts: prefer posts sharing a tag, fall back to recent{% endcomment %}
+      {% assign related = "" | split: "" %}
+      {% for tag in page.tags %}
+        {% for post in site.tags[tag] %}
+          {% unless post.url == page.url %}
+            {% assign related = related | push: post %}
+          {% endunless %}
+        {% endfor %}
+      {% endfor %}
+      {% assign related = related | uniq | slice: 0, 3 %}
+      {% if related.size == 0 %}
+        {% assign related = site.posts | where_exp: "post", "post.url != page.url" | slice: 0, 3 %}
+      {% endif %}
+
+      {% if related.size > 0 %}
+      <section class="post-related">
+        <h2 class="post-related-heading">More posts</h2>
+        <div class="post-related-grid">
+          {% for post in related %}
+          <a href="{{ post.url }}" class="post-related-card">
+            {% if post.tags.size > 0 %}
+            <div class="post-tags post-related-tags">{% for tag in post.tags %}<span class="post-tag">#{{ tag }}</span>{% endfor %}</div>
+            {% endif %}
+            <p class="post-related-title">{{ post.title }}</p>
+            <p class="post-related-date">{{ post.date | date: "%b %-d, %Y" }}</p>
+          </a>
+          {% endfor %}
+        </div>
+      </section>
+      {% endif %}
+
       <footer class="post-footer">
         <a href="/posts/" class="btn btn-secondary">← Back to all posts</a>
       </footer>

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -661,52 +661,105 @@ button { font-family: inherit; }
   font-weight: 600;
 }
 
-/* === POST LAYOUT === */
-.post-header {
+/* === POST PAGE === */
+.post-page {
   padding-top: calc(var(--nav-height) + 3rem);
+  padding-bottom: 5rem;
+}
+
+.post-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.825rem;
+  font-weight: 500;
+  margin-bottom: 2.5rem;
+  transition: color var(--transition);
+}
+
+.post-back:hover {
+  color: var(--text);
+}
+
+.post-header {
+  margin-bottom: 2.5rem;
   padding-bottom: 2rem;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 2.5rem;
 }
 
-.post-header h1 {
-  font-size: clamp(1.5rem, 5vw, 2.25rem);
+/* Hashtag tags above title */
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.post-tag {
+  font-size: 0.825rem;
+  font-weight: 500;
+  color: var(--accent);
+  cursor: default;
+  user-select: none;
+}
+
+.post-title {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
   font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: 0.75rem;
-  line-height: 1.2;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  margin-bottom: 1rem;
+  color: var(--text);
 }
 
-.post-date {
+.post-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem 0.6rem;
+  flex-wrap: wrap;
   font-size: 0.875rem;
   color: var(--text-muted);
 }
 
+.meta-sep {
+  color: var(--border);
+}
+
+/* Post prose typography */
 .post-body {
-  padding-bottom: 5rem;
+  font-size: 1.0625rem;
+  line-height: 1.85;
 }
 
 .post-body h2,
 .post-body h3,
 .post-body h4 {
   font-weight: 600;
-  margin-top: 2rem;
+  margin-top: 2.5rem;
   margin-bottom: 0.75rem;
   letter-spacing: -0.01em;
+  color: var(--text);
 }
 
+.post-body h2 { font-size: 1.375rem; }
+.post-body h3 { font-size: 1.125rem; }
+.post-body h4 { font-size: 1rem; }
+
 .post-body p {
-  margin-bottom: 1rem;
-  line-height: 1.8;
+  margin-bottom: 1.25rem;
   color: var(--text-muted);
 }
 
 .post-body a {
   color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .post-body a:hover {
-  text-decoration: underline;
+  color: var(--accent-hover);
 }
 
 .post-body pre {
@@ -715,7 +768,8 @@ button { font-family: inherit; }
   border-radius: var(--radius);
   padding: 1.25rem;
   overflow-x: auto;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
 }
 
 .post-body code {
@@ -734,26 +788,38 @@ button { font-family: inherit; }
 .post-body ul,
 .post-body ol {
   padding-left: 1.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
 }
 
 .post-body li {
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
   line-height: 1.75;
   color: var(--text-muted);
 }
 
 .post-body blockquote {
   border-left: 3px solid var(--accent);
-  padding-left: 1rem;
-  margin: 1.5rem 0;
+  padding: 0.5rem 0 0.5rem 1.25rem;
+  margin: 2rem 0;
   color: var(--text-muted);
   font-style: italic;
 }
 
+.post-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2.5rem 0;
+}
+
 .post-body img {
   border-radius: var(--radius);
-  margin: 1.5rem 0;
+  margin: 2rem 0;
+}
+
+.post-footer {
+  padding-top: 3rem;
+  margin-top: 3rem;
+  border-top: 1px solid var(--border);
 }
 
 /* === POSTS LIST PAGE === */
@@ -772,8 +838,8 @@ button { font-family: inherit; }
 .posts-list-item {
   display: flex;
   gap: 1.5rem;
-  align-items: baseline;
-  padding: 1rem 0;
+  align-items: flex-start;
+  padding: 1.1rem 0;
   border-bottom: 1px solid var(--border);
   text-decoration: none;
   color: var(--text);
@@ -789,6 +855,13 @@ button { font-family: inherit; }
   color: var(--text-muted);
   flex-shrink: 0;
   width: 95px;
+  padding-top: 0.15rem;
+}
+
+.post-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
 }
 
 .post-item-title {
@@ -799,6 +872,12 @@ button { font-family: inherit; }
 
 .posts-list-item:hover .post-item-title {
   color: var(--accent);
+}
+
+.post-item-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .posts-pagination {

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -817,9 +817,64 @@ button { font-family: inherit; }
 }
 
 .post-footer {
+  padding-top: 2rem;
+  margin-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+/* === RELATED POSTS === */
+.post-related {
   padding-top: 3rem;
   margin-top: 3rem;
   border-top: 1px solid var(--border);
+}
+
+.post-related-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 1.25rem;
+}
+
+.post-related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.post-related-card {
+  display: block;
+  padding: 1.1rem 1.25rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color var(--transition), transform var(--transition);
+}
+
+.post-related-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.post-related-tags {
+  margin-bottom: 0.5rem;
+}
+
+.post-related-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-bottom: 0.4rem;
+  color: var(--text);
+}
+
+.post-related-date {
+  font-size: 0.775rem;
+  color: var(--text-muted);
 }
 
 /* === POSTS LIST PAGE === */

--- a/posts/index.html
+++ b/posts/index.html
@@ -13,7 +13,12 @@ permalink: /posts/
       {% for post in paginator.posts %}
       <a class="posts-list-item" href="{{ post.url }}">
         <span class="post-item-date">{{ post.date | date: "%b %d, %Y" }}</span>
-        <span class="post-item-title">{{ post.title }}</span>
+        <span class="post-item-info">
+          <span class="post-item-title">{{ post.title }}</span>
+          {% if post.tags.size > 0 %}
+          <span class="post-item-tags">{% for tag in post.tags %}<span class="post-tag">#{{ tag }}</span>{% endfor %}</span>
+          {% endif %}
+        </span>
       </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Summary

- **New post layout**: hashtag tags displayed above the title, date + estimated reading time in a clean meta row, chevron back-link at the top, "Back to all posts" button at the bottom
- **Better prose typography**: slightly larger text, generous line height, underlined links with offset, improved heading hierarchy
- **Tags on posts list**: each entry now shows its `#hashtag` tags in accent colour below the title
- **Fix posts index 404**: `_posts/index.html` was accidentally renamed into the `_posts/` special directory (which Jekyll ignores for non-date-named files) — moved back to `posts/index.html`

## Test plan

- [ ] Visit `/posts/` — list loads, tags visible under each title
- [ ] Click a post — new header shows tags above title, date + reading time, back links work
- [ ] Toggle dark/light mode on the post page — tags, text, and button all look correct
- [ ] Verify no JS console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)