### PR TITLE
Add cache-busting query string to CSS and JS assets

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,6 +13,6 @@
   </div>
 </footer>
 
-<script src="/assets/js/portfolio.js"></script>
+<script src="/assets/js/portfolio.js?v={{ site.time | date: '%s' }}"></script>
 </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
   <!-- Stylesheet -->
-  <link rel="stylesheet" href="/assets/css/portfolio.css">
+  <link rel="stylesheet" href="/assets/css/portfolio.css?v={{ site.time | date: '%s' }}">
 
   <!-- Feed -->
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="/feed.xml">


### PR DESCRIPTION
Appends the Jekyll build timestamp as ?v=<unix-seconds> to portfolio.css and portfolio.js URLs so browsers always fetch the latest version after a deploy.