### PR TITLE
Add per-page noindex for Impressum and Datenschutz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,7 @@ The `webp` package is needed for `jekyll-webp` to generate WebP images.
 ## Git workflow
 - SSH key: `GIT_SSH_COMMAND="ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes"`
 - Work happens in feature branches (worktrees), PR to master
+
+
+## Codex notes
+- Added by Codex: Set up per-page `noindex` support via front matter (`noindex: true`) and use it on `/impressum/` and `/datenschutz/` to emit `<meta name="robots" content="noindex">` in `_includes/header.html`.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,9 @@
   <title>{% if page.title and page.title != site.title %}{{ page.title }} — {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
   <meta name="author" content="{{ site.author }}">
+  {% if page.noindex %}
+  <meta name="robots" content="noindex">
+  {% endif %}
 
   <!-- Apply saved theme before first paint to prevent flash -->
   <script>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -2,6 +2,7 @@
 title: Datenschutz
 permalink: /datenschutz/
 layout: page
+noindex: true
 ---
 <p>Stand: 30. Oktober 2020</p><h2>Inhaltsübersicht</h2>
  <ul class="index"><li><a class="index-link" href="#m3">Verantwortlicher</a></li><li><a class="index-link" href="#mOverview">Übersicht der Verarbeitungen</a></li><li><a class="index-link" href="#m13">Maßgebliche Rechtsgrundlagen</a></li><li><a class="index-link" href="#m27">Sicherheitsmaßnahmen</a></li><li><a class="index-link" href="#m225">Bereitstellung des Onlineangebotes und Webhosting</a></li><li><a class="index-link" href="#m104">Blogs und Publikationsmedien</a></li><li><a class="index-link" href="#m182">Kontaktaufnahme</a></li><li><a class="index-link" href="#m136">Präsenzen in sozialen Netzwerken (Social Media)</a></li><li><a class="index-link" href="#m328">Plugins und eingebettete Funktionen sowie Inhalte</a></li><li><a class="index-link" href="#m12">Löschung von Daten</a></li><li><a class="index-link" href="#m15">Änderung und Aktualisierung der Datenschutzerklärung</a></li><li><a class="index-link" href="#m10">Rechte der betroffenen Personen</a></li><li><a class="index-link" href="#m42">Begriffsdefinitionen</a></li></ul><h2 id="m3">Verantwortlicher</h2><p>Jan Tede Mehrtens<br>Fohlenweide 8<br>27711 Osterholz-Scharmbeck</p>

--- a/impressum.md
+++ b/impressum.md
@@ -2,6 +2,7 @@
 layout: page
 title: Impressum
 permalink: /impressum/
+noindex: true
 ---
 <h2 id="m46">Diensteanbieter</h2>
 <p>Jan Tede Mehrtens</p>


### PR DESCRIPTION
### Motivation
- Prevent the site’s legal pages from being indexed so the owner’s address is removed from search engine results. 
- Provide an opt-in per-page mechanism so only selected pages emit a `robots: noindex` header.

### Description
- Added a conditional in `_includes/header.html` to emit `<meta name="robots" content="noindex">` when a page sets `noindex: true` in its front matter. 
- Enabled `noindex: true` in the front matter of `impressum.md` and `datenschutz.html` so those pages will be excluded from indexing. 
- Appended a `## Codex notes` entry to `CLAUDE.md` documenting the change and noting that it was added by Codex. 

### Testing
- Ran `bundle exec jekyll build` which completed successfully. 
- Verified the built pages contain the meta tag with `rg -n "<meta name=\"robots\" content=\"noindex\">" _site/impressum/index.html _site/datenschutz/index.html` and both returned the expected matches. 
- Confirmed the homepage does not include a robots meta tag using a targeted `rg` check, which returned no robots tag (expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af5f94b3388325b4fbeeaa1f23ae0a)