### PR TITLE
Add privacy-aware YouTube embed, `post-youtube` layout, and noindex sitemap handling

### DIFF
--- a/_includes/youtube-embed.html
+++ b/_includes/youtube-embed.html
@@ -1,0 +1,28 @@
+{% assign youtube_source = include.youtube_url | default: page.youtube_url %}
+{% assign youtube_title = include.title | default: page.title | default: 'YouTube video' %}
+{% assign youtube_video_id = '' %}
+
+{% if youtube_source contains 'youtu.be/' %}
+  {% assign youtube_video_id = youtube_source | split: 'youtu.be/' | last | split: '?' | first | split: '&' | first %}
+{% elsif youtube_source contains 'youtube.com/watch' and youtube_source contains 'v=' %}
+  {% assign youtube_video_id = youtube_source | split: 'v=' | last | split: '&' | first %}
+{% elsif youtube_source contains 'youtube.com/embed/' %}
+  {% assign youtube_video_id = youtube_source | split: 'youtube.com/embed/' | last | split: '?' | first | split: '&' | first %}
+{% endif %}
+
+{% if youtube_video_id != '' %}
+<section class="youtube-embed" data-youtube-id="{{ youtube_video_id }}" data-youtube-title="{{ youtube_title | escape }}">
+  <div class="youtube-consent" data-youtube-consent-box>
+    <h2>Video ansehen</h2>
+    <p>Zum Abspielen wird eine Verbindung zu YouTube (Google) aufgebaut. Dabei können personenbezogene Daten wie Ihre IP-Adresse übertragen werden.</p>
+    <div class="youtube-consent-actions">
+      <button type="button" class="btn" data-youtube-allow>Einmal erlauben</button>
+      <button type="button" class="btn btn-secondary" data-youtube-allow-remember>Erlauben &amp; merken</button>
+    </div>
+  </div>
+  <div class="youtube-frame-wrap" data-youtube-frame-wrap hidden></div>
+  <noscript>
+    <p>JavaScript ist deaktiviert. Das Video können Sie direkt auf YouTube ansehen: <a href="{{ youtube_source }}" rel="noopener noreferrer" target="_blank">{{ youtube_title }}</a></p>
+  </noscript>
+</section>
+{% endif %}

--- a/_layouts/post-youtube.html
+++ b/_layouts/post-youtube.html
@@ -1,0 +1,70 @@
+{% include header.html %}
+<main id="main-content">
+  <div class="post-page">
+    <div class="container">
+
+      <a href="/posts/" class="post-back">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>
+        All posts
+      </a>
+
+      <header class="post-header">
+        {% if page.tags.size > 0 %}
+        <div class="post-tags">{% for tag in page.tags %}<a class="post-tag" href="/tags/{{ tag | slugify }}/">#{{ tag }}</a>{% endfor %}</div>
+        {% endif %}
+        <h1 class="post-title">{{ page.title }}</h1>
+        <div class="post-meta-row">
+          <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+          <span class="meta-sep" aria-hidden="true">·</span>
+          {% assign words = content | number_of_words %}
+          <span>{{ words | divided_by: 200 | plus: 1 }} min read</span>
+        </div>
+      </header>
+
+      <article class="post-body">
+        {{ content }}
+      </article>
+
+      {% if page.youtube_url %}
+        {% include youtube-embed.html youtube_url=page.youtube_url title=page.title %}
+      {% endif %}
+
+      {% comment %}Related posts: prefer posts sharing a tag, fall back to recent{% endcomment %}
+      {% assign related = "" | split: "" %}
+      {% for tag in page.tags %}
+        {% for post in site.tags[tag] %}
+          {% unless post.url == page.url %}
+            {% assign related = related | push: post %}
+          {% endunless %}
+        {% endfor %}
+      {% endfor %}
+      {% assign related = related | uniq | slice: 0, 3 %}
+      {% if related.size == 0 %}
+        {% assign related = site.posts | where_exp: "post", "post.url != page.url" | slice: 0, 3 %}
+      {% endif %}
+
+      {% if related.size > 0 %}
+      <section class="post-related">
+        <h2 class="post-related-heading">More posts</h2>
+        <div class="post-related-grid">
+          {% for post in related %}
+          <div class="post-related-card">
+            {% if post.tags.size > 0 %}
+            <div class="post-tags post-related-tags">{% for tag in post.tags %}<a class="post-tag" href="/tags/{{ tag | slugify }}/">#{{ tag }}</a>{% endfor %}</div>
+            {% endif %}
+            <p class="post-related-title"><a href="{{ post.url }}">{{ post.title }}</a></p>
+            <p class="post-related-date">{{ post.date | date: "%b %-d, %Y" }}</p>
+          </div>
+          {% endfor %}
+        </div>
+      </section>
+      {% endif %}
+
+      <footer class="post-footer">
+        <a href="/posts/" class="btn btn-secondary">← Back to all posts</a>
+      </footer>
+
+    </div>
+  </div>
+</main>
+{% include footer.html %}

--- a/_plugins/noindex_sitemap.rb
+++ b/_plugins/noindex_sitemap.rb
@@ -1,0 +1,6 @@
+# Ensure documents explicitly marked as noindex are omitted from sitemap.xml.
+Jekyll::Hooks.register %i[pages posts documents], :pre_render do |doc|
+  next unless doc.data['noindex']
+
+  doc.data['sitemap'] = false
+end

--- a/_posts/2026-03-10-youtube-kategorie-test.md
+++ b/_posts/2026-03-10-youtube-kategorie-test.md
@@ -1,0 +1,11 @@
+---
+layout: post-youtube
+title: "YouTube: Homelab Update in 2 Minuten"
+date: 2026-03-09T12:00:00+01:00
+description: "Kurzes Video-Update aus dem Homelab mit den wichtigsten Änderungen der letzten Wochen."
+tags:
+  - youtube
+  - homelab
+youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+---
+Ein kurzes Video mit den wichtigsten Änderungen im Homelab und einem kleinen Ausblick auf die nächsten Themen.

--- a/_templates/post.md
+++ b/_templates/post.md
@@ -4,6 +4,9 @@ title: "Post Title"
 date: 2026-01-01 12:00:00 +0100
 description: "Short description for SEO and link previews (1-2 sentences)."
 tags: []
+# Optional for video posts:
+# layout: post-youtube
+# youtube_url: "https://www.youtube.com/watch?v=VIDEO_ID"
 ---
 
 Write your post here.

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -989,6 +989,48 @@ button { font-family: inherit; }
   color: var(--text-muted);
 }
 
+/* === YOUTUBE EMBED CONSENT === */
+.youtube-embed {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.youtube-consent,
+.youtube-frame-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  padding: 1.25rem;
+}
+
+.youtube-consent h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.youtube-consent p {
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.youtube-consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.youtube-frame-wrap {
+  padding: 0;
+  overflow: hidden;
+}
+
+.youtube-frame-wrap iframe {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 0;
+}
+
 /* === TAG PAGE === */
 .tag-page-heading {
   font-size: clamp(1.75rem, 5vw, 2.25rem);

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -158,8 +158,62 @@
     });
   }
 
+  function initYouTubeConsent() {
+    const embeds = Array.from(document.querySelectorAll('.youtube-embed[data-youtube-id]'));
+    if (!embeds.length) return;
+
+    const CONSENT_KEY = 'youtube-consent';
+
+    function createFrame(embed) {
+      const id = embed.dataset.youtubeId;
+      const title = embed.dataset.youtubeTitle || 'YouTube video';
+      const frameWrap = embed.querySelector('[data-youtube-frame-wrap]');
+      const consentBox = embed.querySelector('[data-youtube-consent-box]');
+      if (!id || !frameWrap || !consentBox) return;
+
+      frameWrap.innerHTML = '';
+      const iframe = document.createElement('iframe');
+      iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(id)}?rel=0`;
+      iframe.title = title;
+      iframe.loading = 'lazy';
+      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+      iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+      iframe.allowFullscreen = true;
+      frameWrap.appendChild(iframe);
+
+      consentBox.hidden = true;
+      frameWrap.hidden = false;
+    }
+
+    function grantConsent(embed, remember) {
+      if (remember) {
+        localStorage.setItem(CONSENT_KEY, 'granted');
+      }
+      createFrame(embed);
+    }
+
+    const globalConsent = localStorage.getItem(CONSENT_KEY) === 'granted';
+    embeds.forEach((embed) => {
+      if (globalConsent) {
+        createFrame(embed);
+        return;
+      }
+
+      const allowBtn = embed.querySelector('[data-youtube-allow]');
+      const rememberBtn = embed.querySelector('[data-youtube-allow-remember]');
+
+      if (allowBtn) {
+        allowBtn.addEventListener('click', () => grantConsent(embed, false));
+      }
+      if (rememberBtn) {
+        rememberBtn.addEventListener('click', () => grantConsent(embed, true));
+      }
+    });
+  }
+
   initThemePicker();
   initMouseSpotlight();
   initHeroConstellation();
   initMobileNavigation();
+  initYouTubeConsent();
 })();

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -22,6 +22,11 @@ noindex: true
 <h2>Cookies und vergleichbare Technologien</h2>
 <p>Es werden keine Analyse- oder Marketing-Cookies eingesetzt. Für die optionale Darstellung des Dark-/Light-Mode wird ausschließlich ein lokaler Eintrag im Browser-Speicher (<code>localStorage</code>) verwendet. Dieser Eintrag wird nicht an den Server übertragen und enthält keine personenbezogenen Daten.</p>
 
+<h2>YouTube-Einbettungen (nur nach Einwilligung)</h2>
+<p>Auf einzelnen Beitragsseiten können YouTube-Videos eingebettet sein. Eine Verbindung zu YouTube wird erst aufgebaut, wenn Sie dies aktiv erlauben.</p>
+<p>Nach Ihrer Zustimmung erfolgt die Einbindung über <code>youtube-nocookie.com</code>. Dabei können technisch notwendige Daten wie IP-Adresse und Browser-Informationen an YouTube/Google übermittelt werden.</p>
+<p>Die Freigabe kann einmalig oder dauerhaft erfolgen. Bei dauerhafter Freigabe wird Ihre Entscheidung lokal im Browser über <code>localStorage</code> (Schlüssel <code>youtube-consent</code>) gespeichert und kann durch Löschen der Browserdaten widerrufen werden.</p>
+
 <h2>Externe Links</h2>
 <p>Diese Website enthält Links zu externen Seiten (z.&nbsp;B. LinkedIn). Beim Anklicken gelten die Datenschutzbestimmungen der jeweiligen Betreiber.</p>
 


### PR DESCRIPTION
### Motivation

- Provide a privacy-friendly YouTube embedding workflow that requires explicit user consent before loading third-party content. 
- Offer a dedicated post layout for video posts to present content and related posts consistently. 
- Ensure pages marked `noindex` are omitted from the sitemap to avoid indexing internal/privacy pages.

### Description

- Add `_includes/youtube-embed.html` to parse YouTube URLs, show a consent UI, and fall back to a `noscript` link when JavaScript is disabled. 
- Add `_layouts/post-youtube.html` as a new post layout that renders content, includes the YouTube embed when `youtube_url` is present, and shows related posts. 
- Implement client-side consent handling in `assets/js/portfolio.js` via a new `initYouTubeConsent` function that stores durable consent in `localStorage` under the key `youtube-consent` and inserts an iframe using `youtube-nocookie.com` when allowed. 
- Add styles for the consent UI and iframe wrapper in `assets/css/portfolio.css` under the `/* === YOUTUBE EMBED CONSENT === */` section. 
- Add `_plugins/noindex_sitemap.rb` to set `doc.data['sitemap'] = false` for any document with `noindex` set. 
- Document the video option in `_templates/post.md` and add an example video post `_posts/2026-03-10-youtube-kategorie-test.md`. 
- Update `datenschutz.html` to document the YouTube consent behavior and localStorage usage.

### Testing

- Ran a local site build with `bundle exec jekyll build`, which completed successfully and emitted the new layout, include and example post without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af70bf25d883259e48a0c209f31771)