### PR TITLE
Remove permalink from posts index page

### DIFF
--- a/posts/index.html
+++ b/posts/index.html
@@ -1,7 +1,6 @@
 ---
 title: Blog
 layout: home
-permalink: /posts/
 description: Blog-Übersicht mit Artikeln zu Infrastruktur, Automatisierung und persönlichem Tech-Alltag.
 ---
 


### PR DESCRIPTION
## Summary
Removed the explicit `permalink: /posts/` configuration from the posts index page layout.

## Changes
- Removed the `permalink: /posts/` front matter line from `posts/index.html`

## Details
This change allows Jekyll to use its default permalink generation based on the file path rather than an explicitly defined one. The page will continue to be accessible at `/posts/` through Jekyll's default behavior for index files in directories.

https://claude.ai/code/session_01W6AKsoST76z6HqqGvXoXKh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated URL generation configuration for the posts index page to use default slug behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->