### PR TITLE
Improve talks display logic to show more past talks when no upcoming talks

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,8 +101,11 @@ image: /assets/img/IMG_1249.jpeg
 {% assign upcoming_talks = upcoming_talks | sort: "date" %}
 {% assign past_talks = past_talks | sort: "date" | reverse %}
 {% assign next_upcoming = upcoming_talks | first %}
-{% assign display_talks = past_talks | slice: 0, 3 %}
-{% if next_upcoming %}{% assign display_talks = display_talks | unshift: next_upcoming %}{% endif %}
+{% if next_upcoming %}
+  {% assign display_talks = past_talks | slice: 0, 3 | unshift: next_upcoming %}
+{% else %}
+  {% assign display_talks = past_talks | slice: 0, 4 %}
+{% endif %}
 {% if display_talks.size > 0 %}
 <section class="section" id="speaking">
   <div class="container">


### PR DESCRIPTION
## Summary
Refactored the talks display logic to optimize the number of talks shown based on whether there are upcoming talks scheduled.

## Key Changes
- Consolidated the talks filtering logic into a conditional statement that handles two cases:
  - When an upcoming talk exists: display it along with the 3 most recent past talks (4 total)
  - When no upcoming talk exists: display the 4 most recent past talks
- Improved code readability by combining the `slice` and `unshift` operations into a single assignment when an upcoming talk is present

## Implementation Details
The refactoring maintains the same visual output while making the logic more explicit and maintainable. Previously, the code always sliced 3 past talks and conditionally added the upcoming talk, which could result in showing only 3 talks when no upcoming talk existed. Now it explicitly handles both scenarios to ensure consistent content density on the page.

https://claude.ai/code/session_01PXtawVCWTevXKJTqvf63dA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Speaking section now displays more past talks when upcoming engagements are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->