### PR TITLE
fix: mobile nav closes immediately when tapping the SVG icon (#45)

### DIFF
--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -154,7 +154,7 @@
     });
 
     document.addEventListener('click', (event) => {
-      if (!navLinks.contains(event.target) && event.target !== navToggle) closeMenu();
+      if (!navLinks.contains(event.target) && !navToggle.contains(event.target)) closeMenu();
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation menu behavior to prevent unintended closing when interacting with the navigation toggle button or its surrounding area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->